### PR TITLE
Fixing CI Docker Image

### DIFF
--- a/docker-compose.ci.build.yml
+++ b/docker-compose.ci.build.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
     ci-build:
-        image: microsoft/dotnet:1.0.0-preview2.1-sdk
+        image: microsoft/dotnet:1.0.1-sdk-projectjson
         volumes:
             - ./service-b:/src
         working_dir: /src


### PR DESCRIPTION
Seems like the current image doesn't exist anymore.  Updating to the correct version resolves the issue.